### PR TITLE
Pr/1553

### DIFF
--- a/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/upgrade/ContextConfigurationUpgrader.java
+++ b/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/upgrade/ContextConfigurationUpgrader.java
@@ -64,7 +64,8 @@ public class ContextConfigurationUpgrader extends AbstractConfigurationUpgrader<
             com.devonfw.cobigen.impl.config.entity.io.v2_1.ContextConfiguration.class);
         upgradedConfig_2_1.setVersion(new BigDecimal("2.1"));
 
-        result.setResultConfigurationJaxbRootNodeAndPath(upgradedConfig_2_1, configurationRoot);
+        result.setResultConfigurationJaxbRootNodeAndPath(upgradedConfig_2_1,
+            configurationRoot.resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME));
         results.add(result);
 
         break;

--- a/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/upgrade/TemplateConfigurationUpgrader.java
+++ b/cobigen/cobigen-core/src/main/java/com/devonfw/cobigen/impl/config/upgrade/TemplateConfigurationUpgrader.java
@@ -42,7 +42,8 @@ public class TemplateConfigurationUpgrader extends AbstractConfigurationUpgrader
   @Override
   protected List<ConfigurationUpgradeResult> performNextUpgradeStep(TemplatesConfigurationVersion source,
       Object previousConfigurationRootNode, Path configurationRoot) throws Exception {
-	List<ConfigurationUpgradeResult> results = new ArrayList<>();
+
+    List<ConfigurationUpgradeResult> results = new ArrayList<>();
     ConfigurationUpgradeResult result = new ConfigurationUpgradeResult();
 
     switch (source) {
@@ -68,7 +69,32 @@ public class TemplateConfigurationUpgrader extends AbstractConfigurationUpgrader
             previousConfigurationRootNode, com.devonfw.cobigen.impl.config.entity.io.v2_1.TemplatesConfiguration.class);
         upgradedConfig.setVersion(new BigDecimal("2.1"));
 
-        result.setResultConfigurationJaxbRootNodeAndPath(upgradedConfig, null);
+        result.setResultConfigurationJaxbRootNodeAndPath(upgradedConfig,
+            configurationRoot.resolve(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME));
+        results.add(result);
+      }
+        break;
+      case v2_1: { // to 4.0
+        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().mapNulls(true).useAutoMapping(true).build();
+        MapperFacade mapper = mapperFactory.getMapperFacade();
+        com.devonfw.cobigen.impl.config.entity.io.v4_0.TemplatesConfiguration upgradedConfig = mapper.map(
+            previousConfigurationRootNode, com.devonfw.cobigen.impl.config.entity.io.v4_0.TemplatesConfiguration.class);
+        upgradedConfig.setVersion(new BigDecimal("4.0"));
+
+        result.setResultConfigurationJaxbRootNodeAndPath(upgradedConfig,
+            configurationRoot.resolve(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME));
+        results.add(result);
+      }
+        break;
+      case v4_0: { // to 5.0
+        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().mapNulls(true).useAutoMapping(true).build();
+        MapperFacade mapper = mapperFactory.getMapperFacade();
+        com.devonfw.cobigen.impl.config.entity.io.v5_0.TemplatesConfiguration upgradedConfig = mapper.map(
+            previousConfigurationRootNode, com.devonfw.cobigen.impl.config.entity.io.v5_0.TemplatesConfiguration.class);
+        upgradedConfig.setVersion(new BigDecimal("5.0"));
+
+        result.setResultConfigurationJaxbRootNodeAndPath(upgradedConfig,
+            configurationRoot.resolve(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME));
         results.add(result);
       }
         break;

--- a/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/upgrade/ContextConfigurationUpgraderTest.java
+++ b/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/upgrade/ContextConfigurationUpgraderTest.java
@@ -34,31 +34,75 @@ public class ContextConfigurationUpgraderTest extends AbstractUnitTest {
   public TemporaryFolder tempFolder = new TemporaryFolder();
 
   /**
-   * Tests the valid upgrade of a context configuration from version v2.0 to the latest version. Please make sure that
-   * .../ContextConfigurationUpgraderTest/valid-latest_version exists
+   * Tests the valid upgrade of a context configuration from version v2.0 to v2.1. Please make sure that
+   * .../ContextConfigurationUpgraderTest/valid-v2.1 exists
    *
    * @throws Exception test fails
    */
   @Test
-  public void testCorrectUpgrade_v2_0_TO_LATEST() throws Exception {
+  public void testCorrectUpgrade_v2_0_TO_v_2_1() throws Exception {
 
     // preparation
+    ContextConfigurationVersion currentVersion = ContextConfigurationVersion.v2_0;
+    ContextConfigurationVersion targetVersion = ContextConfigurationVersion.v2_1;
+    String currentVersionPath = "valid-v2.0";
+    String targetVersionPath = "valid-v2.1";
+
+    Path cobigen = this.tempFolder.newFolder(ConfigurationConstants.COBIGEN_CONFIG_FILE).toPath();
+    Path context = cobigen.resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
+    File sourceTestdata = new File(contextTestFileRootPath + File.separator + currentVersionPath + File.separator
+        + ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
+
+    FileUtils.copyDirectory(new File(contextTestFileRootPath + File.separator + currentVersionPath), cobigen.toFile());
+
+    ContextConfigurationUpgrader sut = new ContextConfigurationUpgrader();
+
+    ContextConfigurationVersion version = sut.resolveLatestCompatibleSchemaVersion(cobigen, currentVersion);
+    assertThat(version).as("Source Version").isEqualTo(currentVersion);
+
+    sut.upgradeConfigurationToLatestVersion(cobigen, BackupPolicy.ENFORCE_BACKUP, targetVersion);
+    assertThat(cobigen.resolve("context.bak.xml").toFile()).exists().hasSameContentAs(sourceTestdata);
+
+    version = sut.resolveLatestCompatibleSchemaVersion(cobigen, targetVersion);
+    assertThat(version).as("Target version").isEqualTo(targetVersion);
+
+    XMLUnit.setIgnoreWhitespace(true);
+    new XMLTestCase() {
+    }.assertXMLEqual(new FileReader(contextTestFileRootPath + File.separator + targetVersionPath + File.separator
+        + ConfigurationConstants.CONTEXT_CONFIG_FILENAME), new FileReader(context.toFile()));
+  }
+
+  /**
+   * Tests the valid upgrade of a context configuration from version v2.1 to v3.0. Please make sure that
+   * .../ContextConfigurationUpgraderTest/valid-v3.0 exists
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testCorrectUpgrade_v2_1_TO_v3_0() throws Exception {
+
+    // preparation
+    ContextConfigurationVersion currentVersion = ContextConfigurationVersion.v2_1;
+    ContextConfigurationVersion targetVersion = ContextConfigurationVersion.v3_0;
+    String currentVersionPath = "valid-2.1";
+    String targetVersionPath = "valid-v3.0";
+
     File cobigen = this.tempFolder.newFolder(ConfigurationConstants.COBIGEN_CONFIG_FILE);
     Path templates = cobigen.toPath().resolve(ConfigurationConstants.CONFIG_PROPERTY_TEMPLATES_PATH)
         .resolve(ConfigurationConstants.COBIGEN_TEMPLATES).resolve(ConfigurationConstants.TEMPLATE_RESOURCE_FOLDER);
     Path context = templates.resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
 
-    FileUtils.copyDirectory(new File(templateTestFileRootPath + "/valid-2.0"), cobigen);
+    FileUtils.copyDirectory(new File(templateTestFileRootPath + File.separator + currentVersionPath), cobigen);
 
     ContextConfigurationUpgrader sut = new ContextConfigurationUpgrader();
 
-    ContextConfigurationVersion version = sut.resolveLatestCompatibleSchemaVersion(templates);
-    assertThat(version).as("Source Version").isEqualTo(ContextConfigurationVersion.v2_1);
+    ContextConfigurationVersion version = sut.resolveLatestCompatibleSchemaVersion(templates, currentVersion);
+    assertThat(version).as("Source Version").isEqualTo(currentVersion);
 
-    sut.upgradeConfigurationToLatestVersion(templates, BackupPolicy.ENFORCE_BACKUP);
+    sut.upgradeConfigurationToLatestVersion(templates, BackupPolicy.ENFORCE_BACKUP, targetVersion);
     // copy resources again to check if backup was successful
     String pom = "templates/CobiGen_Templates/pom.xml";
-    FileUtils.copyDirectory(new File(templateTestFileRootPath + "/valid-2.0"), cobigen);
+    FileUtils.copyDirectory(new File(templateTestFileRootPath + File.separator + currentVersionPath), cobigen);
     assertThat(cobigen.toPath().resolve("backup").resolve(pom).toFile()).exists()
         .hasSameContentAs(cobigen.toPath().resolve(pom).toFile());
 
@@ -74,85 +118,94 @@ public class ContextConfigurationUpgraderTest extends AbstractUnitTest {
     for (String s : newTemplatesLocation.toFile().list()) {
       Path newContextPath = newTemplatesLocation.resolve(s).resolve(ConfigurationConstants.TEMPLATE_RESOURCE_FOLDER);
 
-      version = sut.resolveLatestCompatibleSchemaVersion(newContextPath);
-      assertThat(version).as("Target version").isEqualTo(ContextConfigurationVersion.getLatest());
+      version = sut.resolveLatestCompatibleSchemaVersion(newContextPath, targetVersion);
+      assertThat(version).as("Target version").isEqualTo(targetVersion);
 
       newContextPath = newContextPath.resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
       XMLUnit.setIgnoreWhitespace(true);
       new XMLTestCase() {
-      }.assertXMLEqual(new FileReader(contextTestFileRootPath + "/valid-" + ContextConfigurationVersion.getLatest()
-          + "/" + s + "/" + ConfigurationConstants.CONTEXT_CONFIG_FILENAME), new FileReader(newContextPath.toFile()));
+      }.assertXMLEqual(
+          new FileReader(contextTestFileRootPath + File.separator + targetVersionPath + File.separator + s
+              + File.separator + ConfigurationConstants.CONTEXT_CONFIG_FILENAME),
+          new FileReader(newContextPath.toFile()));
 
     }
   }
 
   /**
-   * Tests the valid upgrade of a context configuration from version v2.1 to the latest version. Please make sure that
-   * .../ContextConfigurationUpgraderTest/valid-latest_version exists
+   * Tests if v2.0 context configuration is compatible to v2.0 schema.
    *
    * @throws Exception test fails
    */
   @Test
-  public void testCorrectUpgrade_v2_1_TO_LATEST() throws Exception {
+  public void testCorrectV2_0SchemaDetection() throws Exception {
 
     // preparation
-    File cobigen = this.tempFolder.newFolder(ConfigurationConstants.COBIGEN_CONFIG_FILE);
-    Path templates = cobigen.toPath().resolve(ConfigurationConstants.CONFIG_PROPERTY_TEMPLATES_PATH)
-        .resolve(ConfigurationConstants.COBIGEN_TEMPLATES).resolve(ConfigurationConstants.TEMPLATE_RESOURCE_FOLDER);
-    Path context = templates.resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
+    ContextConfigurationVersion currentVersion = ContextConfigurationVersion.v2_0;
+    File targetConfig = new File(contextTestFileRootPath + "/valid-" + currentVersion);
 
-    FileUtils.copyDirectory(new File(templateTestFileRootPath + "/valid-2.1"), cobigen);
-
-    ContextConfigurationUpgrader sut = new ContextConfigurationUpgrader();
-
-    ContextConfigurationVersion version = sut.resolveLatestCompatibleSchemaVersion(templates);
-    assertThat(version).as("Source Version").isEqualTo(ContextConfigurationVersion.v2_1);
-
-    sut.upgradeConfigurationToLatestVersion(templates, BackupPolicy.ENFORCE_BACKUP);
-    // copy resources again to check if backup was successful
-    String pom = "templates/CobiGen_Templates/pom.xml";
-    FileUtils.copyDirectory(new File(templateTestFileRootPath + "/valid-2.1"), cobigen);
-    assertThat(cobigen.toPath().resolve("backup").resolve(pom).toFile()).exists()
-        .hasSameContentAs(cobigen.toPath().resolve(pom).toFile());
-
-    Path newTemplatesLocation = cobigen.toPath().resolve(ConfigurationConstants.TEMPLATE_SETS_FOLDER)
-        .resolve(ConfigurationConstants.ADAPTED_FOLDER);
-    Path backupContextPath = cobigen.toPath().resolve("backup")
-        .resolve(ConfigurationConstants.CONFIG_PROPERTY_TEMPLATES_PATH)
-        .resolve(ConfigurationConstants.COBIGEN_TEMPLATES).resolve(ConfigurationConstants.TEMPLATE_RESOURCE_FOLDER)
-        .resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
-
-    assertThat(backupContextPath.toFile()).exists().hasSameContentAs(context.toFile());
-
-    for (String s : newTemplatesLocation.toFile().list()) {
-      Path newContextPath = newTemplatesLocation.resolve(s).resolve(ConfigurationConstants.TEMPLATE_RESOURCE_FOLDER);
-
-      version = sut.resolveLatestCompatibleSchemaVersion(newContextPath);
-      assertThat(version).as("Target version").isEqualTo(ContextConfigurationVersion.getLatest());
-
-      newContextPath = newContextPath.resolve(ConfigurationConstants.CONTEXT_CONFIG_FILENAME);
-      XMLUnit.setIgnoreWhitespace(true);
-      new XMLTestCase() {
-      }.assertXMLEqual(new FileReader(contextTestFileRootPath + "/valid-" + ContextConfigurationVersion.getLatest()
-          + "/" + s + "/" + ConfigurationConstants.CONTEXT_CONFIG_FILENAME), new FileReader(newContextPath.toFile()));
-
+    for (File context : targetConfig.listFiles()) {
+      ContextConfigurationVersion version = new ContextConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
     }
   }
 
   /**
-   * Tests if latest context configuration is compatible to latest schema version.
+   * Tests if v2.1 context configuration is compatible to v2.1 schema.
    *
    * @throws Exception test fails
    */
   @Test
-  public void testCorrectLatestSchemaDetection() throws Exception {
+  public void testCorrectV2_1SchemaDetection() throws Exception {
 
     // preparation
-    File targetConfig = new File(contextTestFileRootPath + "/valid-" + ContextConfigurationVersion.getLatest());
+    ContextConfigurationVersion currentVersion = ContextConfigurationVersion.v2_1;
+    File targetConfig = new File(contextTestFileRootPath + "/valid-" + currentVersion);
+
+    for (File context : targetConfig.listFiles()) {
+      ContextConfigurationVersion version = new ContextConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
+    }
+  }
+
+  /**
+   * Tests if v3.0 context configuration is compatible to v3.0 schema.
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testCorrectV3_0SchemaDetection() throws Exception {
+
+    // preparation
+    ContextConfigurationVersion currentVersion = ContextConfigurationVersion.v3_0;
+    File targetConfig = new File(contextTestFileRootPath + "/valid-" + currentVersion);
+
+    for (File context : targetConfig.listFiles()) {
+      ContextConfigurationVersion version = new ContextConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
+    }
+  }
+
+  /**
+   * Tests if v3.0 context configuration schema is not compatible to v2.1 configuration file.
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testV2_1IsIncompatibleToV3_0Schema() throws Exception {
+
+    // preparation
+    ContextConfigurationVersion currentVersion = ContextConfigurationVersion.v2_1;
+    ContextConfigurationVersion targetVersion = ContextConfigurationVersion.v3_0;
+    File targetConfig = new File(contextTestFileRootPath + "/valid-" + currentVersion);
+
     for (File context : targetConfig.listFiles()) {
       ContextConfigurationVersion version = new ContextConfigurationUpgrader()
           .resolveLatestCompatibleSchemaVersion(context.toPath());
-      assertThat(version).isEqualTo(ContextConfigurationVersion.getLatest());
+      assertThat(version).isNotEqualTo(targetVersion);
     }
   }
 }

--- a/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/upgrade/TemplateConfigurationUpgraderTest.java
+++ b/cobigen/cobigen-core/src/test/java/com/devonfw/cobigen/unittest/config/upgrade/TemplateConfigurationUpgraderTest.java
@@ -31,75 +31,47 @@ public class TemplateConfigurationUpgraderTest extends AbstractUnitTest {
   public TemporaryFolder tempFolder = new TemporaryFolder();
 
   /**
-   * Tests the valid upgrade of a templates configuration from version v1.2 to the latest version.
+   * Tests the valid upgrade of a templates configuration from version v1.2 to v2.1.
    *
    * @throws Exception test fails
    */
   @Test
-  public void testCorrectUpgrade_v1_2_TO_LATEST() throws Exception {
+  public void testCorrectUpgrade_v1_2_TO_2_1() throws Exception {
 
     // preparation
     File tmpTargetConfig = this.tempFolder.newFile(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
     File sourceTestdata = new File(testFileRootPath + "valid-v1.2/" + ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
     Files.copy(sourceTestdata, tmpTargetConfig);
 
+    TemplatesConfigurationVersion currentVersion = TemplatesConfigurationVersion.v1_2;
+    TemplatesConfigurationVersion targetVersion = TemplatesConfigurationVersion.v2_1;
+
     TemplateConfigurationUpgrader sut = new TemplateConfigurationUpgrader();
 
-    TemplatesConfigurationVersion version = sut
-        .resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath());
-    assertThat(version).as("Source Version").isEqualTo(TemplatesConfigurationVersion.v1_2);
+    TemplatesConfigurationVersion version = sut.resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath(),
+        targetVersion);
+    assertThat(version).as("Source Version").isEqualTo(currentVersion);
 
-    sut.upgradeConfigurationToLatestVersion(this.tempFolder.getRoot().toPath(), BackupPolicy.ENFORCE_BACKUP);
+    sut.upgradeConfigurationToLatestVersion(this.tempFolder.getRoot().toPath(), BackupPolicy.ENFORCE_BACKUP,
+        targetVersion);
     assertThat(tmpTargetConfig.toPath().resolveSibling("templates.bak.xml").toFile()).exists()
         .hasSameContentAs(sourceTestdata);
 
-    version = sut.resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath());
-    assertThat(version).as("Target version").isEqualTo(TemplatesConfigurationVersion.getLatest());
+    version = sut.resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath(), targetVersion);
+    assertThat(version).as("Target version").isEqualTo(targetVersion);
 
     XMLUnit.setIgnoreWhitespace(true);
-    try (FileReader vgl = new FileReader(testFileRootPath + "valid-" + TemplatesConfigurationVersion.getLatest() + "/"
-        + ConfigurationConstants.TEMPLATES_CONFIG_FILENAME); FileReader tmp = new FileReader(tmpTargetConfig)) {
+    try (
+        FileReader vgl = new FileReader(
+            testFileRootPath + "valid-" + targetVersion + "/" + ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
+        FileReader tmp = new FileReader(tmpTargetConfig)) {
       new XMLTestCase() {
       }.assertXMLEqual(vgl, tmp);
     }
   }
 
   /**
-   * Tests the valid upgrade of a templates configuration from version v2.1 to the latest version.
-   *
-   * @throws Exception test fails
-   */
-  @Test
-  public void testCorrectUpgrade_v2_1_TO_LATEST() throws Exception {
-
-    // preparation
-    File tmpTargetConfig = this.tempFolder.newFile(ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
-    File sourceTestdata = new File(testFileRootPath + "valid-v2.1/" + ConfigurationConstants.TEMPLATES_CONFIG_FILENAME);
-    Files.copy(sourceTestdata, tmpTargetConfig);
-
-    TemplateConfigurationUpgrader sut = new TemplateConfigurationUpgrader();
-
-    TemplatesConfigurationVersion version = sut
-        .resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath());
-    assertThat(version).as("Source Version").isEqualTo(TemplatesConfigurationVersion.v2_1);
-
-    sut.upgradeConfigurationToLatestVersion(this.tempFolder.getRoot().toPath(), BackupPolicy.ENFORCE_BACKUP);
-    assertThat(tmpTargetConfig.toPath().resolveSibling("templates.bak.xml").toFile()).exists()
-        .hasSameContentAs(sourceTestdata);
-
-    version = sut.resolveLatestCompatibleSchemaVersion(this.tempFolder.getRoot().toPath());
-    assertThat(version).as("Target version").isEqualTo(TemplatesConfigurationVersion.getLatest());
-
-    XMLUnit.setIgnoreWhitespace(true);
-    try (FileReader vgl = new FileReader(testFileRootPath + "valid-" + TemplatesConfigurationVersion.getLatest() + "/"
-        + ConfigurationConstants.TEMPLATES_CONFIG_FILENAME); FileReader tmp = new FileReader(tmpTargetConfig)) {
-      new XMLTestCase() {
-      }.assertXMLEqual(vgl, tmp);
-    }
-  }
-
-  /**
-   * Tests the valid upgrade of a templates configuration from version v1.2 to v2.1.
+   * Tests if latest templates configuration is compatible to latest schema version.
    *
    * @throws Exception test fails
    */
@@ -113,4 +85,81 @@ public class TemplateConfigurationUpgraderTest extends AbstractUnitTest {
         .resolveLatestCompatibleSchemaVersion(targetConfig.toPath());
     assertThat(version).isEqualTo(TemplatesConfigurationVersion.getLatest());
   }
+
+  /**
+   * Tests if v1.2 template configuration is compatible to v1.2 schema.
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testCorrectV1_2SchemaDetection() throws Exception {
+
+    // preparation
+    TemplatesConfigurationVersion currentVersion = TemplatesConfigurationVersion.v1_2;
+    File targetConfig = new File(testFileRootPath + "/valid-" + currentVersion);
+
+    for (File context : targetConfig.listFiles()) {
+      TemplatesConfigurationVersion version = new TemplateConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
+    }
+  }
+
+  /**
+   * Tests if v2.1 template configuration is compatible to v2.1 schema.
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testCorrectV2_1SchemaDetection() throws Exception {
+
+    // preparation
+    TemplatesConfigurationVersion currentVersion = TemplatesConfigurationVersion.v2_1;
+    File targetConfig = new File(testFileRootPath + "/valid-" + currentVersion);
+
+    for (File context : targetConfig.listFiles()) {
+      TemplatesConfigurationVersion version = new TemplateConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
+    }
+  }
+
+  /**
+   * Tests if v4.0 template configuration is compatible to v4.0 schema.
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testCorrectV4_0SchemaDetection() throws Exception {
+
+    // preparation
+    TemplatesConfigurationVersion currentVersion = TemplatesConfigurationVersion.v4_0;
+    File targetConfig = new File(testFileRootPath + "/valid-" + currentVersion);
+
+    for (File context : targetConfig.listFiles()) {
+      TemplatesConfigurationVersion version = new TemplateConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
+    }
+  }
+
+  /**
+   * Tests if v5.0 template configuration is compatible to v5.0 schema.
+   *
+   * @throws Exception test fails
+   */
+  @Test
+  public void testCorrectV5_0SchemaDetection() throws Exception {
+
+    // preparation
+    TemplatesConfigurationVersion currentVersion = TemplatesConfigurationVersion.v5_0;
+    File targetConfig = new File(testFileRootPath + "/valid-" + currentVersion);
+
+    for (File context : targetConfig.listFiles()) {
+      TemplatesConfigurationVersion version = new TemplateConfigurationUpgrader()
+          .resolveLatestCompatibleSchemaVersion(context.toPath(), currentVersion);
+      assertThat(version).isEqualTo(currentVersion);
+    }
+  }
+
 }

--- a/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/upgrade/TemplatesConfigurationUpgraderTest/valid-v5.0/templates.xml
+++ b/cobigen/cobigen-core/src/test/resources/testdata/unittest/config/upgrade/TemplatesConfigurationUpgraderTest/valid-v5.0/templates.xml
@@ -15,10 +15,10 @@
   </templateScans>
 
   <increments>
-    <increment name="gui_spring" description="Spring configuration" explanation="This does x">
+    <increment name="gui_spring" description="Spring configuration">
       <templateRef ref="resources_resources_spring_common" />
     </increment>
-    <increment name="gui" description="GUI" explanation="this does y">
+    <increment name="gui" description="GUI">
       <incrementRef ref="gui_spring" />
     </increment>
   </increments>


### PR DESCRIPTION
Adresses/Fixes #1553.

Implements

#1533 fixed upgrade tests

- re-introduced version to version test (removed upgrade to latest version tests)
- re-introduced schema version validation tests (removed validate against latest schema test)
- refactored resolveLatestCompatibleSchemaVersion
- added new maxVersion param for tests (limits the versions list to the provided maximum version)
- added new limitVersions method (limits the versions list to provided maximum version)
- added new isConfgurationFileCompatibleToSchemaVersion method (checks if the version is compatible to the configuration file)
- added new testV2_1IsIncompatibleToV3_0Schema test to make sure that v3.0 is not backwards compatible to v2.1

@devonfw/cobigen
